### PR TITLE
NODE-2815: docker-wallarm-node: added ACL support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ COPY conf/logrotate.conf /etc/
 COPY conf/default /etc/nginx/sites-enabled/
 COPY conf/wallarm-status.conf /etc/nginx/conf.d/
 COPY conf/collectd.conf /etc/collectd/
+COPY conf/wallarm-acl.conf /etc/nginx/conf.d/
+COPY conf/nginx-blacklistonly.conf /etc/nginx/
 
 EXPOSE 80 443
 

--- a/conf/default
+++ b/conf/default
@@ -18,6 +18,7 @@ server {
 
         # wallarm_mode monitoring;
         # wallarm_instance 1;
+        # wallarm_acl default;
 
         location / {
                 proxy_pass http://127.0.0.1:8080;

--- a/conf/nginx-blacklistonly.conf
+++ b/conf/nginx-blacklistonly.conf
@@ -1,0 +1,12 @@
+# A very simple nginx configuration file that forces nginx to start to fill acl db.
+user www-data;
+pid /tmp/nginx.pid;
+
+load_module /usr/lib/nginx/modules/ngx_http_wallarm_module.so;
+error_log /dev/stdout;
+
+events {}
+http {
+  include /etc/nginx/conf.d/wallarm-acl.conf;
+}
+daemon off;

--- a/conf/wallarm-acl.conf
+++ b/conf/wallarm-acl.conf
@@ -1,0 +1,21 @@
+wallarm_acl_db default {
+  wallarm_acl_path /var/lib/nginx/wallarm_acl_default;
+  wallarm_acl_mapsize 64m;
+}
+
+server {
+  listen 127.0.0.9:80;
+
+  server_name localhost;
+
+  allow 127.0.0.0/8;
+  deny all;
+
+  wallarm_mode off;
+  access_log off;
+
+  location /wallarm-acl {
+    wallarm_acl default;
+    wallarm_acl_api on;
+  }
+}

--- a/scripts/init
+++ b/scripts/init
@@ -83,6 +83,26 @@ sync_node() {
   done
 }
 
+configure_acl() {
+  sed -i -e "s@# wallarm_acl .*@wallarm_acl default;@" /etc/nginx/sites-enabled/default
+  sed -i -e '/sync-blacklist/s/^#//' /etc/cron.d/wallarm-node-nginx
+  grep -q "sync_blacklist:" /etc/wallarm/node.yaml || \
+    printf 'sync_blacklist:\n    nginx_url: http://127.0.0.9:80/wallarm-acl' >> /etc/wallarm/node.yaml
+  /usr/sbin/nginx -c /etc/nginx/nginx-blacklistonly.conf &
+  cmd="/usr/share/wallarm-common/sync-blacklist --one-time -l STDOUT"
+
+  while true; do
+    if runuser -u wallarm -- $cmd; then
+      break
+    else
+      echo "Wait before next sync-blacklist attempt..."
+      sleep 5
+    fi
+  done
+  kill $!
+  wait
+}
+
 configure_nginx() {
   [ -n "$NGINX_BACKEND" ] || return 0
 
@@ -121,5 +141,6 @@ prepare_dirs
 register_node
 sync_node
 configure_nginx
+[ ! -z ${WALLARM_ACL_ENABLE+x} ] && configure_acl
 
 exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
ACL support can be activated by passing env variable WALLARM_ACL_ENABLE
(may contain any value). Without this variable old behaviour will be
preserved.