### PR TITLE
NODE-3095: docker-wallarm-node: exit if no NGINX_BACKEND passed

### DIFF
--- a/scripts/init
+++ b/scripts/init
@@ -116,6 +116,10 @@ if [ -z "$DEPLOY_USER" ] || [ -z "$DEPLOY_PASSWORD" ]; then
   fi
 fi
 
+if [ -z "$NGINX_BACKEND" ]; then
+  echo "ERROR: no NGINX_BACKEND specified, nothing to protect" >&2
+  exit 1
+fi
 
 prepare_dirs
 register_node


### PR DESCRIPTION
If no NGINX_BACKEND passed there is nothing to protect. So exit early.